### PR TITLE
feat: export generic models which can be extended

### DIFF
--- a/higlass_schema/schema.py
+++ b/higlass_schema/schema.py
@@ -15,10 +15,10 @@ from typing import (
 )
 
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import Extra, Field, validator
+from pydantic import Extra, Field
 from pydantic.class_validators import root_validator
 from pydantic.generics import GenericModel as PydanticGenericModel
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Literal, TypedDict, Annotated
 
 from .utils import exclude_properties_titles, get_schema_of, simplify_enum_schema
 import functools
@@ -265,6 +265,7 @@ class ValueScaleLocks(BaseModel):
 # Tracks                                         #
 ##################################################
 
+TrackTypeT = TypeVar("TrackTypeT", bound=str)
 TrackOptions = Dict[str, Any]
 TilesetInfo = Dict[str, Any]
 Tile = Dict[str, Any]
@@ -280,10 +281,7 @@ class Data(BaseModel):
     tiles: Optional[Tile] = None
 
 
-TrackType = TypeVar("TrackType", bound=str)
-
-
-class BaseTrack(GenericModel, Generic[TrackType]):
+class BaseTrack(GenericModel, Generic[TrackTypeT]):
     class Config:
         extra = Extra.forbid
 
@@ -294,7 +292,7 @@ class BaseTrack(GenericModel, Generic[TrackType]):
                 schema["properties"]["type"]
             )
 
-    type: TrackType
+    type: TrackTypeT
     uid: Optional[str] = None
     width: Optional[int] = None
     height: Optional[int] = None
@@ -533,8 +531,8 @@ class Viewconf(GenericModel, Generic[ViewT]):
     zoomFixed: Optional[bool] = None
     compactLayout: Optional[bool] = None
     exportViewUrl: Optional[str] = None
-    trackSourceServers: Optional[List[str]] = Field(..., min_items=1)
-    views: Optional[List[ViewT]] = Field(..., min_items=1)
+    trackSourceServers: Optional[Annotated[List[str], Field(..., min_items=1)]] = None
+    views: Optional[Annotated[List[ViewT], Field(..., min_items=1)]] = None
     zoomLocks: Optional[ZoomLocks] = None
     locationLocks: Optional[LocationLocks] = None
     valueScaleLocks: Optional[ValueScaleLocks] = None


### PR DESCRIPTION
## Motivation

I'd like to use this library as the core for a higlass-python v2 (https://github.com/manzt/hg). This means that I'd like to extend the behavior of some of the schema models (e.g. `EnumTrack`, `View`, `Viewconf`) with methods for updating properties, creating unique copies, etc.

However, with concrete Models (derived from `pydantic.BaseModel`), there is not a mechanism to extend the children with new behavior. As an example.

```python
import higlass_schema as hgs

class _PropertiesMixin:

    # modify the fields of a pydantic model in place or return a copy with updates 
    def properties(self, inplace: bool = False, **fields):
        model = self if inplace else _copy_unique(self)
        for k, v in fields.items():
            setattr(model, k, v)
        return model


class Viewconf(hgs.Viewconf, _PropertiesMixin):
   ...

class HeatmapTrack(hgs.HeatmapTrack, _PropertiesMixin):
   ...
```

I extended the behavior of some of the builtin types, which now lets me use this new API.

```python
track = HeatmapTrack(type='heatmap').properties(width=200) # HeatmapTrack
```

However the issue occurs when I parse a file and try to use the API above.

```python
parsed_track = Viewconf.parse_file('example.json').views[0].tracks.top[0] # hgs.HeatmapTrack
parsed_track.properties() # error!
``` 

Since `hgs.Viewconf` is implemented concretely, the deserialized track does not inherit the extended API. This means that python API built on top of these types will need to try to handle both cases which is confusing and challenging. 

With generics, end users of `higlass_schema` can extend generic models and the top level `Viewconf` will consistently serialize/deserialize the new defined types.

```python
from higlass_schema import Viewconf # Generic, and defaults to bounds set on each TypeVar
import hg # Concrete, and serializes to extended types

Viewconf.parse_file('example.json').views[0].tracks.top[0].properties() # error!
hg.Viewconf.parse_file('example.json').views[0].tracks.trop[0].properties() # hg.EnumTrack
```